### PR TITLE
Updated trigger selection for trigger efficiency studies

### DIFF
--- a/Analysis/Mjj_Mjjj.py
+++ b/Analysis/Mjj_Mjjj.py
@@ -277,7 +277,7 @@ if __name__ == "__main__":
     numberOfGenEventsHisto[0] = numberOfGenEvents
 
     event_counts = {}
-    first_bin = ("Total" if "JetHT" not in process else "Dataset")
+    first_bin = ("Total" if "JetHT" not in process else "Dataset_and_skim")
     
     regions = ["SR_boosted", "VR_boosted", "SR_semiboosted", "VR_semiboosted"]
     for r in regions:

--- a/Analysis/Mjj_Mjjj.py
+++ b/Analysis/Mjj_Mjjj.py
@@ -17,134 +17,94 @@ j2_start=0
 j2_stop=6000
 
 
-def plotboosted(boosted_SR_fail, boosted_SR_pass, boosted_VR_fail, boosted_VR_pass, process):
+def fillHistos(label, SR_fail_fj, SR_pass_fj, VR_fail_fj, VR_pass_fj, SR_fail_j=None, SR_pass_j=None, VR_fail_j=None, VR_pass_j=None):
 
-    trijet_mass_SR_fail = (boosted_SR_fail[:,0]+boosted_SR_fail[:,1]+boosted_SR_fail[:,2]).mass
-    trijet_mass_SR_pass = (boosted_SR_pass[:,0]+boosted_SR_pass[:,1]+boosted_SR_pass[:,2]).mass
+    isBoosted = ("semiboosted" not in label.lower())
+    hists = {}
 
-    trijet_mass_VR_fail = (boosted_VR_fail[:,0]+boosted_VR_fail[:,1]+boosted_VR_fail[:,2]).mass
-    trijet_mass_VR_pass = (boosted_VR_pass[:,0]+boosted_VR_pass[:,1]+boosted_VR_pass[:,2]).mass
+    if isBoosted:
+        trijet_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_fj[:,1]+SR_fail_fj[:,2]).mass
+        trijet_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_fj[:,1]+SR_pass_fj[:,2]).mass
 
-    j3_SR_fail_bin = hist.axis.Regular(label="Boosted Signal Fail Trijet Mass [GeV]", name="trijet_mass_SR_fail", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_SR_fail_hist = Hist(j3_SR_fail_bin, storage="weight")
-    j3_SR_fail_hist.fill(trijet_mass_SR_fail=trijet_mass_SR_fail)
+        trijet_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_fj[:,1]+VR_fail_fj[:,2]).mass
+        trijet_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_fj[:,1]+VR_pass_fj[:,2]).mass
+    else:
+        trijet_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_fj[:,1]+SR_fail_j[:,0]['i0']+SR_fail_j[:,0]['i1']).mass
+        trijet_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_fj[:,1]+SR_pass_j[:,0]['i0']+SR_pass_j[:,0]['i1']).mass
 
-    j3_SR_pass_bin = hist.axis.Regular(label="Boosted Signal Pass Trijet Mass [GeV]", name="trijet_mass_SR_pass", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_SR_pass_hist = Hist(j3_SR_pass_bin, storage="weight")
-    j3_SR_pass_hist.fill(trijet_mass_SR_pass=trijet_mass_SR_pass)
-
-    j3_VR_fail_bin = hist.axis.Regular(label="Boosted Validation Fail Trijet Mass [GeV]", name="trijet_mass_VR_fail", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_VR_fail_hist = Hist(j3_VR_fail_bin, storage="weight")
-    j3_VR_fail_hist.fill(trijet_mass_VR_fail=trijet_mass_VR_fail)
-
-    j3_VR_pass_bin = hist.axis.Regular(label="Boosted Validation Pass Trijet Mass [GeV]", name="trijet_mass_VR_pass", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_VR_pass_hist = Hist(j3_VR_pass_bin, storage="weight")
-    j3_VR_pass_hist.fill(trijet_mass_VR_pass=trijet_mass_VR_pass)
-
-    dijet1_mass_SR_fail = (boosted_SR_fail[:,0]+boosted_SR_fail[:,1]).mass
-    dijet2_mass_SR_fail = (boosted_SR_fail[:,0]+boosted_SR_fail[:,2]).mass
-    dijet3_mass_SR_fail = (boosted_SR_fail[:,1]+boosted_SR_fail[:,2]).mass
-    dijet1_mass_SR_pass = (boosted_SR_pass[:,0]+boosted_SR_pass[:,1]).mass
-    dijet2_mass_SR_pass = (boosted_SR_pass[:,0]+boosted_SR_pass[:,2]).mass
-    dijet3_mass_SR_pass = (boosted_SR_pass[:,1]+boosted_SR_pass[:,2]).mass
-
-    dijet1_mass_VR_fail = (boosted_VR_fail[:,0]+boosted_VR_fail[:,1]).mass
-    dijet2_mass_VR_fail = (boosted_VR_fail[:,0]+boosted_VR_fail[:,2]).mass
-    dijet3_mass_VR_fail = (boosted_VR_fail[:,1]+boosted_VR_fail[:,2]).mass
-    dijet1_mass_VR_pass = (boosted_VR_pass[:,0]+boosted_VR_pass[:,1]).mass
-    dijet2_mass_VR_pass = (boosted_VR_pass[:,0]+boosted_VR_pass[:,2]).mass
-    dijet3_mass_VR_pass = (boosted_VR_pass[:,1]+boosted_VR_pass[:,2]).mass
-
-    j2_SR_fail_bin = hist.axis.Regular(label="Boosted Signal Fail Dijet Mass [GeV]", name="dijet_mass_SR_fail", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_SR_fail = Hist(j3_SR_fail_bin, j2_SR_fail_bin, storage="weight")
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet1_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet2_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet3_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
-
-    j2_SR_pass_bin = hist.axis.Regular(label="Boosted Signal Pass Dijet Mass [GeV]", name="dijet_mass_SR_pass", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_SR_pass = Hist(j3_SR_pass_bin, j2_SR_pass_bin, storage="weight")
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet1_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet2_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet3_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
-
-    j2_VR_fail_bin = hist.axis.Regular(label="Boosted Validation Fail Dijet Mass [GeV]", name="dijet_mass_VR_fail", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_VR_fail = Hist(j3_VR_fail_bin, j2_VR_fail_bin, storage="weight")
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet1_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet2_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet3_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
-
-    j2_VR_pass_bin = hist.axis.Regular(label="Boosted Validation Pass Dijet Mass [GeV]", name="dijet_mass_VR_pass", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_VR_pass = Hist(j3_VR_pass_bin, j2_VR_pass_bin, storage="weight")
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet1_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet2_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet3_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
-
-    return j3_SR_fail_hist,j3_SR_pass_hist,j3_VR_fail_hist,j3_VR_pass_hist,mjj_vs_mjjj_SR_fail,mjj_vs_mjjj_SR_pass,mjj_vs_mjjj_VR_fail,mjj_vs_mjjj_VR_pass
-
-
-def plotsemiboosted(label, semiboosted_SR_fail_fatjet, semiboosted_SR_pass_fatjet, semiboosted_SR_fail_jet, semiboosted_SR_pass_jet, semiboosted_VR_fail_fatjet, semiboosted_VR_pass_fatjet, semiboosted_VR_fail_jet, semiboosted_VR_pass_jet, process):
-
-    trijet_mass_SR_fail = (semiboosted_SR_fail_fatjet[:,0]+semiboosted_SR_fail_fatjet[:,1]+semiboosted_SR_fail_jet[:,0]['i0']+semiboosted_SR_fail_jet[:,0]['i1']).mass
-    trijet_mass_SR_pass = (semiboosted_SR_pass_fatjet[:,0]+semiboosted_SR_pass_fatjet[:,1]+semiboosted_SR_pass_jet[:,0]['i0']+semiboosted_SR_pass_jet[:,0]['i1']).mass
-
-    trijet_mass_VR_fail = (semiboosted_VR_fail_fatjet[:,0]+semiboosted_VR_fail_fatjet[:,1]+semiboosted_VR_fail_jet[:,0]['i0']+semiboosted_VR_fail_jet[:,0]['i1']).mass
-    trijet_mass_VR_pass = (semiboosted_VR_pass_fatjet[:,0]+semiboosted_VR_pass_fatjet[:,1]+semiboosted_VR_pass_jet[:,0]['i0']+semiboosted_VR_pass_jet[:,0]['i1']).mass
+        trijet_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_fj[:,1]+VR_fail_j[:,0]['i0']+VR_fail_j[:,0]['i1']).mass
+        trijet_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_fj[:,1]+VR_pass_j[:,0]['i0']+VR_pass_j[:,0]['i1']).mass
 
     j3_SR_fail_bin = hist.axis.Regular(label=f"{label} Signal Fail Trijet Mass [GeV]", name="trijet_mass_SR_fail", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_SR_fail_hist = Hist(j3_SR_fail_bin, storage="weight")
-    j3_SR_fail_hist.fill(trijet_mass_SR_fail=trijet_mass_SR_fail)
+    hists["j3_SR_fail"] = Hist(j3_SR_fail_bin, storage="weight")
+    hists["j3_SR_fail"].fill(trijet_mass_SR_fail=trijet_mass_SR_fail)
 
     j3_SR_pass_bin = hist.axis.Regular(label=f"{label} Signal Pass Trijet Mass [GeV]", name="trijet_mass_SR_pass", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_SR_pass_hist = Hist(j3_SR_pass_bin, storage="weight")
-    j3_SR_pass_hist.fill(trijet_mass_SR_pass=trijet_mass_SR_pass)
+    hists["j3_SR_pass"] = Hist(j3_SR_pass_bin, storage="weight")
+    hists["j3_SR_pass"].fill(trijet_mass_SR_pass=trijet_mass_SR_pass)
 
     j3_VR_fail_bin = hist.axis.Regular(label=f"{label} Validation Fail Trijet Mass [GeV]", name="trijet_mass_VR_fail", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_VR_fail_hist = Hist(j3_VR_fail_bin, storage="weight")
-    j3_VR_fail_hist.fill(trijet_mass_VR_fail=trijet_mass_VR_fail)
+    hists["j3_VR_fail"] = Hist(j3_VR_fail_bin, storage="weight")
+    hists["j3_VR_fail"].fill(trijet_mass_VR_fail=trijet_mass_VR_fail)
 
     j3_VR_pass_bin = hist.axis.Regular(label=f"{label} Validation Pass Trijet Mass [GeV]", name="trijet_mass_VR_pass", bins=j3_bins, start=j3_start, stop=j3_stop)
-    j3_VR_pass_hist = Hist(j3_VR_pass_bin, storage="weight")
-    j3_VR_pass_hist.fill(trijet_mass_VR_pass=trijet_mass_VR_pass)
+    hists["j3_VR_pass"] = Hist(j3_VR_pass_bin, storage="weight")
+    hists["j3_VR_pass"].fill(trijet_mass_VR_pass=trijet_mass_VR_pass)
 
-    dijet1_mass_SR_fail = (semiboosted_SR_fail_fatjet[:,0]+semiboosted_SR_fail_fatjet[:,1]).mass
-    dijet2_mass_SR_fail = (semiboosted_SR_fail_fatjet[:,0]+semiboosted_SR_fail_jet[:,0]['i0']+semiboosted_SR_fail_jet[:,0]['i1']).mass
-    dijet3_mass_SR_fail = (semiboosted_SR_fail_fatjet[:,1]+semiboosted_SR_fail_jet[:,0]['i0']+semiboosted_SR_fail_jet[:,0]['i1']).mass
-    dijet1_mass_SR_pass = (semiboosted_SR_pass_fatjet[:,0]+semiboosted_SR_pass_fatjet[:,1]).mass
-    dijet2_mass_SR_pass = (semiboosted_SR_pass_fatjet[:,0]+semiboosted_SR_pass_jet[:,0]['i0']+semiboosted_SR_pass_jet[:,0]['i1']).mass
-    dijet3_mass_SR_pass = (semiboosted_SR_pass_fatjet[:,1]+semiboosted_SR_pass_jet[:,0]['i0']+semiboosted_SR_pass_jet[:,0]['i1']).mass
+    if isBoosted:
+        dijet1_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_fj[:,1]).mass
+        dijet2_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_fj[:,2]).mass
+        dijet3_mass_SR_fail = (SR_fail_fj[:,1]+SR_fail_fj[:,2]).mass
+        dijet1_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_fj[:,1]).mass
+        dijet2_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_fj[:,2]).mass
+        dijet3_mass_SR_pass = (SR_pass_fj[:,1]+SR_pass_fj[:,2]).mass
 
-    dijet1_mass_VR_fail = (semiboosted_VR_fail_fatjet[:,0]+semiboosted_VR_fail_fatjet[:,1]).mass
-    dijet2_mass_VR_fail = (semiboosted_VR_fail_fatjet[:,0]+semiboosted_VR_fail_jet[:,0]['i0']+semiboosted_VR_fail_jet[:,0]['i1']).mass
-    dijet3_mass_VR_fail = (semiboosted_VR_fail_fatjet[:,1]+semiboosted_VR_fail_jet[:,0]['i0']+semiboosted_VR_fail_jet[:,0]['i1']).mass
-    dijet1_mass_VR_pass = (semiboosted_VR_pass_fatjet[:,0]+semiboosted_VR_pass_fatjet[:,1]).mass
-    dijet2_mass_VR_pass = (semiboosted_VR_pass_fatjet[:,0]+semiboosted_VR_pass_jet[:,0]['i0']+semiboosted_VR_pass_jet[:,0]['i1']).mass
-    dijet3_mass_VR_pass = (semiboosted_VR_pass_fatjet[:,1]+semiboosted_VR_pass_jet[:,0]['i0']+semiboosted_VR_pass_jet[:,0]['i1']).mass
+        dijet1_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_fj[:,1]).mass
+        dijet2_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_fj[:,2]).mass
+        dijet3_mass_VR_fail = (VR_fail_fj[:,1]+VR_fail_fj[:,2]).mass
+        dijet1_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_fj[:,1]).mass
+        dijet2_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_fj[:,2]).mass
+        dijet3_mass_VR_pass = (VR_pass_fj[:,1]+VR_pass_fj[:,2]).mass
+    else:
+        dijet1_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_fj[:,1]).mass
+        dijet2_mass_SR_fail = (SR_fail_fj[:,0]+SR_fail_j[:,0]['i0']+SR_fail_j[:,0]['i1']).mass
+        dijet3_mass_SR_fail = (SR_fail_fj[:,1]+SR_fail_j[:,0]['i0']+SR_fail_j[:,0]['i1']).mass
+        dijet1_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_fj[:,1]).mass
+        dijet2_mass_SR_pass = (SR_pass_fj[:,0]+SR_pass_j[:,0]['i0']+SR_pass_j[:,0]['i1']).mass
+        dijet3_mass_SR_pass = (SR_pass_fj[:,1]+SR_pass_j[:,0]['i0']+SR_pass_j[:,0]['i1']).mass
+
+        dijet1_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_fj[:,1]).mass
+        dijet2_mass_VR_fail = (VR_fail_fj[:,0]+VR_fail_j[:,0]['i0']+VR_fail_j[:,0]['i1']).mass
+        dijet3_mass_VR_fail = (VR_fail_fj[:,1]+VR_fail_j[:,0]['i0']+VR_fail_j[:,0]['i1']).mass
+        dijet1_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_fj[:,1]).mass
+        dijet2_mass_VR_pass = (VR_pass_fj[:,0]+VR_pass_j[:,0]['i0']+VR_pass_j[:,0]['i1']).mass
+        dijet3_mass_VR_pass = (VR_pass_fj[:,1]+VR_pass_j[:,0]['i0']+VR_pass_j[:,0]['i1']).mass
 
     j2_SR_fail_bin = hist.axis.Regular(label=f"{label} Signal Fail Dijet Mass [GeV]", name="dijet_mass_SR_fail", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_SR_fail = Hist(j3_SR_fail_bin, j2_SR_fail_bin, storage="weight")
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet1_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet2_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
-    mjj_vs_mjjj_SR_fail.fill(dijet_mass_SR_fail=dijet3_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
+    hists["mjj_vs_mjjj_SR_fail"] = Hist(j3_SR_fail_bin, j2_SR_fail_bin, storage="weight")
+    hists["mjj_vs_mjjj_SR_fail"].fill(dijet_mass_SR_fail=dijet1_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
+    hists["mjj_vs_mjjj_SR_fail"].fill(dijet_mass_SR_fail=dijet2_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
+    hists["mjj_vs_mjjj_SR_fail"].fill(dijet_mass_SR_fail=dijet3_mass_SR_fail,trijet_mass_SR_fail=trijet_mass_SR_fail)
 
     j2_SR_pass_bin = hist.axis.Regular(label=f"{label} Signal Pass Dijet Mass [GeV]", name="dijet_mass_SR_pass", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_SR_pass = Hist(j3_SR_pass_bin, j2_SR_pass_bin, storage="weight")
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet1_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet2_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
-    mjj_vs_mjjj_SR_pass.fill(dijet_mass_SR_pass=dijet3_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
+    hists["mjj_vs_mjjj_SR_pass"] = Hist(j3_SR_pass_bin, j2_SR_pass_bin, storage="weight")
+    hists["mjj_vs_mjjj_SR_pass"].fill(dijet_mass_SR_pass=dijet1_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
+    hists["mjj_vs_mjjj_SR_pass"].fill(dijet_mass_SR_pass=dijet2_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
+    hists["mjj_vs_mjjj_SR_pass"].fill(dijet_mass_SR_pass=dijet3_mass_SR_pass,trijet_mass_SR_pass=trijet_mass_SR_pass)
 
     j2_VR_fail_bin = hist.axis.Regular(label=f"{label} Validation Fail Dijet Mass [GeV]", name="dijet_mass_VR_fail", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_VR_fail = Hist(j3_VR_fail_bin, j2_VR_fail_bin, storage="weight")
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet1_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet2_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
-    mjj_vs_mjjj_VR_fail.fill(dijet_mass_VR_fail=dijet3_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
+    hists["mjj_vs_mjjj_VR_fail"] = Hist(j3_VR_fail_bin, j2_VR_fail_bin, storage="weight")
+    hists["mjj_vs_mjjj_VR_fail"].fill(dijet_mass_VR_fail=dijet1_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
+    hists["mjj_vs_mjjj_VR_fail"].fill(dijet_mass_VR_fail=dijet2_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
+    hists["mjj_vs_mjjj_VR_fail"].fill(dijet_mass_VR_fail=dijet3_mass_VR_fail,trijet_mass_VR_fail=trijet_mass_VR_fail)
 
     j2_VR_pass_bin = hist.axis.Regular(label=f"{label} Validation Pass Dijet Mass [GeV]", name="dijet_mass_VR_pass", bins=j2_bins, start=j2_start, stop=j2_stop)
-    mjj_vs_mjjj_VR_pass = Hist(j3_VR_pass_bin, j2_VR_pass_bin, storage="weight")
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet1_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet2_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
-    mjj_vs_mjjj_VR_pass.fill(dijet_mass_VR_pass=dijet3_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
+    hists["mjj_vs_mjjj_VR_pass"] = Hist(j3_VR_pass_bin, j2_VR_pass_bin, storage="weight")
+    hists["mjj_vs_mjjj_VR_pass"].fill(dijet_mass_VR_pass=dijet1_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
+    hists["mjj_vs_mjjj_VR_pass"].fill(dijet_mass_VR_pass=dijet2_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
+    hists["mjj_vs_mjjj_VR_pass"].fill(dijet_mass_VR_pass=dijet3_mass_VR_pass,trijet_mass_VR_pass=trijet_mass_VR_pass)
 
-    return j3_SR_fail_hist,j3_SR_pass_hist,j3_VR_fail_hist,j3_VR_pass_hist,mjj_vs_mjjj_SR_fail,mjj_vs_mjjj_SR_pass,mjj_vs_mjjj_VR_fail,mjj_vs_mjjj_VR_pass
+    return hists
 
 
 if __name__ == "__main__":
@@ -226,25 +186,25 @@ if __name__ == "__main__":
 
     for variation in variations:
 
-        boosted_SR_fail, boosted_SR_pass, boosted_VR_fail, boosted_VR_pass, semiboosted_SR_fail_fatjet, semiboosted_SR_pass_fatjet, semiboosted_SR_fail_jet, semiboosted_SR_pass_jet, semiboosted_VR_fail_fatjet, semiboosted_VR_pass_fatjet, semiboosted_VR_fail_jet, semiboosted_VR_pass_jet, semiboosted_eq2_SR_fail_fatjet, semiboosted_eq2_SR_pass_fatjet, semiboosted_eq2_SR_fail_jet, semiboosted_eq2_SR_pass_jet, semiboosted_eq2_VR_fail_fatjet, semiboosted_eq2_VR_pass_fatjet, semiboosted_eq2_VR_fail_jet, semiboosted_eq2_VR_pass_jet = Event_selection(input,process,event_counts,variation=variation,trigList=args.triggerList,refTrigList=args.refTriggerList,eventsToRead=None)
+        SR_b_fail_e, SR_b_pass_e, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_e, VR_b_pass_e, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_e, SR_sb_pass_e, SR_sb_fail_fj, SR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_e, VR_sb_pass_e, VR_sb_fail_fj, VR_sb_pass_fj, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j = Event_selection(input,process,event_counts,variation=variation,trigList=args.triggerList,refTrigList=args.refTriggerList,eventsToRead=None)
 
         if not saveOnceDone and variation in ["nominal","fromFile"]:
             # give priority to nominal if running both 'nominal' and 'fromFile'
             if variation=="nominal":
                 saveOnceDone = True
 
-            event_counts["SR_boosted"]["Fail"] = len(boosted_SR_fail)
-            event_counts["SR_boosted"]["Pass"] = len(boosted_SR_pass)
-            event_counts["VR_boosted"]["Fail"] = len(boosted_VR_fail)
-            event_counts["VR_boosted"]["Pass"] = len(boosted_VR_pass)
-            event_counts["SR_semiboosted"]["Fail"] = len(semiboosted_SR_fail_fatjet)
-            event_counts["SR_semiboosted"]["Pass"] = len(semiboosted_SR_pass_fatjet)
-            event_counts["VR_semiboosted"]["Fail"] = len(semiboosted_VR_fail_fatjet)
-            event_counts["VR_semiboosted"]["Pass"] = len(semiboosted_VR_pass_fatjet)
-            event_counts["SR_semiboosted"]["Fail"] += len(semiboosted_eq2_SR_fail_fatjet)
-            event_counts["SR_semiboosted"]["Pass"] += len(semiboosted_eq2_SR_pass_fatjet)
-            event_counts["VR_semiboosted"]["Fail"] += len(semiboosted_eq2_VR_fail_fatjet)
-            event_counts["VR_semiboosted"]["Pass"] += len(semiboosted_eq2_VR_pass_fatjet)
+            event_counts["SR_boosted"]["Fail"] = len(SR_b_fail_fj)
+            event_counts["SR_boosted"]["Pass"] = len(SR_b_pass_fj)
+            event_counts["VR_boosted"]["Fail"] = len(VR_b_fail_fj)
+            event_counts["VR_boosted"]["Pass"] = len(VR_b_pass_fj)
+            event_counts["SR_semiboosted"]["Fail"] = len(SR_sb_fail_fj)
+            event_counts["SR_semiboosted"]["Pass"] = len(SR_sb_pass_fj)
+            event_counts["VR_semiboosted"]["Fail"] = len(VR_sb_fail_fj)
+            event_counts["VR_semiboosted"]["Pass"] = len(VR_sb_pass_fj)
+            event_counts["SR_semiboosted"]["Fail"] += len(SR_sb_eq2_fail_fj)
+            event_counts["SR_semiboosted"]["Pass"] += len(SR_sb_eq2_pass_fj)
+            event_counts["VR_semiboosted"]["Fail"] += len(VR_sb_eq2_fail_fj)
+            event_counts["VR_semiboosted"]["Pass"] += len(VR_sb_eq2_pass_fj)
 
             cutFlowHistos = {}
             for r in regions:
@@ -252,48 +212,31 @@ if __name__ == "__main__":
                 for i, key in enumerate(event_counts[r].keys()):
                     cutFlowHistos[r].SetBinContent(i+1, event_counts[r][key])
                     cutFlowHistos[r].GetXaxis().SetBinLabel(i+1, key)
-            
-        j3_SR_fail_boosted,j3_SR_pass_boosted,j3_VR_fail_boosted,j3_VR_pass_boosted,mjj_vs_mjjj_SR_fail_boosted,mjj_vs_mjjj_SR_pass_boosted,mjj_vs_mjjj_VR_fail_boosted,mjj_vs_mjjj_VR_pass_boosted = plotboosted(boosted_SR_fail,boosted_SR_pass,boosted_VR_fail,boosted_VR_pass,process)                  
-        j3_SR_fail_semiboosted,j3_SR_pass_semiboosted,j3_VR_fail_semiboosted,j3_VR_pass_semiboosted,mjj_vs_mjjj_SR_fail_semiboosted,mjj_vs_mjjj_SR_pass_semiboosted,mjj_vs_mjjj_VR_fail_semiboosted,mjj_vs_mjjj_VR_pass_semiboosted = plotsemiboosted("Semiboosted", semiboosted_SR_fail_fatjet, semiboosted_SR_pass_fatjet,semiboosted_SR_fail_jet, semiboosted_SR_pass_jet,semiboosted_VR_fail_fatjet,semiboosted_VR_pass_fatjet,semiboosted_VR_fail_jet,semiboosted_VR_pass_jet,process)
-        j3_SR_fail_semiboosted_eq2,j3_SR_pass_semiboosted_eq2,j3_VR_fail_semiboosted_eq2,j3_VR_pass_semiboosted_eq2,mjj_vs_mjjj_SR_fail_semiboosted_eq2,mjj_vs_mjjj_SR_pass_semiboosted_eq2,mjj_vs_mjjj_VR_fail_semiboosted_eq2,mjj_vs_mjjj_VR_pass_semiboosted_eq2 = plotsemiboosted("Semiboosted_eq2", semiboosted_eq2_SR_fail_fatjet, semiboosted_eq2_SR_pass_fatjet,semiboosted_eq2_SR_fail_jet, semiboosted_eq2_SR_pass_jet,semiboosted_eq2_VR_fail_fatjet,semiboosted_eq2_VR_pass_fatjet,semiboosted_eq2_VR_fail_jet,semiboosted_eq2_VR_pass_jet,process)
-        
+
         if (not saveOnceMCDone and "JetHT" not in process and variation in ["nominal","fromFile"]):
             saveOnceMCDone = True
             outHists[f"numberOfGenEventsHisto"] = numberOfGenEventsHisto
 
+        hists = {}
+        hists["boosted"] = fillHistos("Boosted", SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj)           
+        hists["semiboosted"] = fillHistos("Semiboosted", SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j)
+        hists["semiboosted_eq2"] = fillHistos("Semiboosted_eq2", SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j)
+
+        selections = ["boosted", "semiboosted", "semiboosted_eq2"]
         suffix = ("" if variation=="fromFile" else f"_{variation}")
 
-        outHists[f"j3_SR_pass_boosted{suffix}"] = j3_SR_pass_boosted
-        outHists[f"j3_VR_pass_boosted{suffix}"] = j3_VR_pass_boosted
-        outHists[f"mjj_vs_mjjj_SR_pass_boosted{suffix}"] = mjj_vs_mjjj_SR_pass_boosted
-        outHists[f"mjj_vs_mjjj_VR_pass_boosted{suffix}"] = mjj_vs_mjjj_VR_pass_boosted
-        outHists[f"j3_SR_fail_boosted{suffix}"] = j3_SR_fail_boosted
-        outHists[f"j3_VR_fail_boosted{suffix}"] = j3_VR_fail_boosted
-        outHists[f"mjj_vs_mjjj_SR_fail_boosted{suffix}"] = mjj_vs_mjjj_SR_fail_boosted
-        outHists[f"mjj_vs_mjjj_VR_fail_boosted{suffix}"] = mjj_vs_mjjj_VR_fail_boosted
-        outHists[f"j3_SR_pass_semiboosted{suffix}"] = j3_SR_pass_semiboosted
-        outHists[f"j3_VR_pass_semiboosted{suffix}"] = j3_VR_pass_semiboosted
-        outHists[f"mjj_vs_mjjj_SR_pass_semiboosted{suffix}"] = mjj_vs_mjjj_SR_pass_semiboosted
-        outHists[f"mjj_vs_mjjj_VR_pass_semiboosted{suffix}"] = mjj_vs_mjjj_VR_pass_semiboosted
-        outHists[f"j3_SR_fail_semiboosted{suffix}"] = j3_SR_fail_semiboosted
-        outHists[f"j3_VR_fail_semiboosted{suffix}"] = j3_VR_fail_semiboosted
-        outHists[f"mjj_vs_mjjj_SR_fail_semiboosted{suffix}"] = mjj_vs_mjjj_SR_fail_semiboosted
-        outHists[f"mjj_vs_mjjj_VR_fail_semiboosted{suffix}"] = mjj_vs_mjjj_VR_fail_semiboosted
-        outHists[f"j3_SR_pass_semiboosted_eq2{suffix}"] = j3_SR_pass_semiboosted_eq2
-        outHists[f"j3_VR_pass_semiboosted_eq2{suffix}"] = j3_VR_pass_semiboosted_eq2
-        outHists[f"mjj_vs_mjjj_SR_pass_semiboosted_eq2{suffix}"] = mjj_vs_mjjj_SR_pass_semiboosted_eq2
-        outHists[f"mjj_vs_mjjj_VR_pass_semiboosted_eq2{suffix}"] = mjj_vs_mjjj_VR_pass_semiboosted_eq2
-        outHists[f"j3_SR_fail_semiboosted_eq2{suffix}"] = j3_SR_fail_semiboosted_eq2
-        outHists[f"j3_VR_fail_semiboosted_eq2{suffix}"] = j3_VR_fail_semiboosted_eq2
-        outHists[f"mjj_vs_mjjj_SR_fail_semiboosted_eq2{suffix}"] = mjj_vs_mjjj_SR_fail_semiboosted_eq2
-        outHists[f"mjj_vs_mjjj_VR_fail_semiboosted_eq2{suffix}"] = mjj_vs_mjjj_VR_fail_semiboosted_eq2
-        # for r in regions:
-                # fout[f"cutFlowHisto_{r}"] = cutFlowHistos[r] # this does not work properly (see [*])
-        
+        for sel in selections:
+            for hist in hists[sel]:
+                outHists[f"{hist}_{sel}{suffix}"] = hists[sel][hist]
+
+    # save histograms to a ROOT file
     with uproot.recreate(os.path.join(output, "Histograms_{0}-{1}".format(process, ofile))) as fout:
         for histName in outHists:
             fout[histName] = outHists[histName]
+        #for r in regions:
+            #fout[f"cutFlowHisto_{r}"] = cutFlowHistos[r] # this does not work properly (see [*])
 
+    # re-open the ROOT file for some updates and storing additional histograms
     fout = ROOT.TFile.Open(os.path.join(output, "Histograms_{0}-{1}".format(process, ofile)), 'UPDATE')
     list_of_keys = copy.deepcopy(fout.GetListOfKeys()) # without deepcopy the processing time explodes, no idea why
     for myKey in list_of_keys:

--- a/Analysis/Mjj_Mjjj.py
+++ b/Analysis/Mjj_Mjjj.py
@@ -213,7 +213,7 @@ if __name__ == "__main__":
     numberOfGenEventsHisto[0] = numberOfGenEvents
 
     event_counts = {}
-    first_bin = ("Total" if "JetHT" not in process else "Trigger_and_skim")
+    first_bin = ("Total" if "JetHT" not in process else "Dataset")
     
     regions = ["SR_boosted", "VR_boosted", "SR_semiboosted", "VR_semiboosted"]
     for r in regions:

--- a/Analysis/Mjj_Mjjj.py
+++ b/Analysis/Mjj_Mjjj.py
@@ -17,9 +17,87 @@ j2_start=0
 j2_stop=6000
 
 
-def fillHistos(label, SR_fail_fj, SR_pass_fj, VR_fail_fj, VR_pass_fj, SR_fail_j=None, SR_pass_j=None, VR_fail_j=None, VR_pass_j=None):
+def getTriggerEvtMask(events, trigList):
+    refTriggerBits = np.array([events.HLT[t] for t in trigList if t in events.HLT.fields])
 
-    isBoosted = ("semiboosted" not in label.lower())
+    return np.logical_or.reduce(refTriggerBits, axis=0)
+
+
+def fillHistos(label, event_counts, SR_fail_fj, SR_pass_fj, VR_fail_fj, VR_pass_fj, SR_fail_j=None, SR_pass_j=None, VR_fail_j=None, VR_pass_j=None, SR_fail_e=None, SR_pass_e=None, VR_fail_e=None, VR_pass_e=None, refTrigList=None, trigList=None):
+
+    isBoosted = ("Semiboosted" not in label)
+
+    if refTrigList != None:
+        # SR fail
+        trigEvtMask = getTriggerEvtMask(SR_fail_e, refTrigList)
+        SR_fail_e  =  SR_fail_e[trigEvtMask]
+        SR_fail_fj = SR_fail_fj[trigEvtMask]
+        if not isBoosted:
+            SR_fail_j = SR_fail_j[trigEvtMask]
+        # SR pass
+        trigEvtMask = getTriggerEvtMask(SR_pass_e, refTrigList)
+        SR_pass_e  =  SR_pass_e[trigEvtMask]
+        SR_pass_fj = SR_pass_fj[trigEvtMask]
+        if not isBoosted:
+            SR_pass_j = SR_pass_j[trigEvtMask]
+        # VR fail
+        trigEvtMask = getTriggerEvtMask(VR_fail_e, refTrigList)
+        VR_fail_e  =  VR_fail_e[trigEvtMask]
+        VR_fail_fj = VR_fail_fj[trigEvtMask]
+        if not isBoosted:
+            VR_fail_j = VR_fail_j[trigEvtMask]
+        # VR pass
+        trigEvtMask = getTriggerEvtMask(VR_pass_e, refTrigList)
+        VR_pass_e  =  VR_pass_e[trigEvtMask]
+        VR_pass_fj = VR_pass_fj[trigEvtMask]
+        if not isBoosted:
+            VR_pass_j = VR_pass_j[trigEvtMask]
+
+    if trigList != None:
+        # SR fail
+        trigEvtMask = getTriggerEvtMask(SR_fail_e, trigList)
+        #SR_fail_e  =  SR_fail_e[trigEvtMask]
+        SR_fail_fj = SR_fail_fj[trigEvtMask]
+        if not isBoosted:
+            SR_fail_j = SR_fail_j[trigEvtMask]
+        # SR pass
+        trigEvtMask = getTriggerEvtMask(SR_pass_e, trigList)
+        #SR_pass_e  =  SR_pass_e[trigEvtMask]
+        SR_pass_fj = SR_pass_fj[trigEvtMask]
+        if not isBoosted:
+            SR_pass_j = SR_pass_j[trigEvtMask]
+        # VR fail
+        trigEvtMask = getTriggerEvtMask(VR_fail_e, trigList)
+        #VR_fail_e  =  VR_fail_e[trigEvtMask]
+        VR_fail_fj = VR_fail_fj[trigEvtMask]
+        if not isBoosted:
+            VR_fail_j = VR_fail_j[trigEvtMask]
+        # VR pass
+        trigEvtMask = getTriggerEvtMask(VR_pass_e, trigList)
+        #VR_pass_e  =  VR_pass_e[trigEvtMask]
+        VR_pass_fj = VR_pass_fj[trigEvtMask]
+        if not isBoosted:
+            VR_pass_j = VR_pass_j[trigEvtMask]
+
+    # add trigger selection to the cut flow event counts
+    if refTrigList != None or trigList != None:
+        if isBoosted:
+            event_counts["SR_boosted"]["Fail_trigger"] = len(SR_fail_fj)
+            event_counts["SR_boosted"]["Pass_trigger"] = len(SR_pass_fj)
+            event_counts["VR_boosted"]["Fail_trigger"] = len(VR_fail_fj)
+            event_counts["VR_boosted"]["Pass_trigger"] = len(VR_pass_fj)
+        else:
+            if "eq2" in label:
+                event_counts["SR_semiboosted"]["Fail_trigger"] += len(SR_fail_fj)
+                event_counts["SR_semiboosted"]["Pass_trigger"] += len(SR_pass_fj)
+                event_counts["VR_semiboosted"]["Fail_trigger"] += len(VR_fail_fj)
+                event_counts["VR_semiboosted"]["Pass_trigger"] += len(VR_pass_fj)
+            else:
+                event_counts["SR_semiboosted"]["Fail_trigger"] = len(SR_fail_fj)
+                event_counts["SR_semiboosted"]["Pass_trigger"] = len(SR_pass_fj)
+                event_counts["VR_semiboosted"]["Fail_trigger"] = len(VR_fail_fj)
+                event_counts["VR_semiboosted"]["Pass_trigger"] = len(VR_pass_fj)
+
     hists = {}
 
     if isBoosted:
@@ -107,6 +185,32 @@ def fillHistos(label, SR_fail_fj, SR_pass_fj, VR_fail_fj, VR_pass_fj, SR_fail_j=
     return hists
 
 
+def fillAllHistos(outHists, variation, event_counts, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j, SR_b_fail_e=None, SR_b_pass_e=None, VR_b_fail_e=None, VR_b_pass_e=None, SR_sb_fail_e=None, SR_sb_pass_e=None, VR_sb_fail_e=None, VR_sb_pass_e=None, SR_sb_eq2_fail_e=None, SR_sb_eq2_pass_e=None, VR_sb_eq2_fail_e=None, VR_sb_eq2_pass_e=None, refTrigList=None, trigList=None):
+
+    hists = {}
+    hists["boosted"] = fillHistos("Boosted", event_counts, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj, None, None, None, None, SR_b_fail_e, SR_b_pass_e, VR_b_fail_e, VR_b_pass_e, refTrigList, trigList)
+    hists["semiboosted"] = fillHistos("Semiboosted", event_counts, SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j, SR_sb_fail_e, SR_sb_pass_e, VR_sb_fail_e, VR_sb_pass_e, refTrigList, trigList)
+    hists["semiboosted_eq2"] = fillHistos("Semiboosted_eq2", event_counts, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, refTrigList, trigList)
+
+    selections = ["boosted", "semiboosted", "semiboosted_eq2"]
+    suffix = ("" if variation=="fromFile" else f"_{variation}")
+    if refTrigList != None or trigList != None:
+        suffix += "_"
+        if refTrigList != None and trigList == None:
+            suffix += "ref"
+        elif refTrigList != None and trigList != None:
+            suffix += "refAndAn"
+        else:
+            suffix += "an"
+        suffix += "Trig"
+
+    for sel in selections:
+        for hist in hists[sel]:
+            outHists[f"{hist}_{sel}{suffix}"] = hists[sel][hist]
+
+    return
+
+
 if __name__ == "__main__":
     import time
     start_time = time.time()
@@ -186,13 +290,9 @@ if __name__ == "__main__":
 
     for variation in variations:
 
-        SR_b_fail_e, SR_b_pass_e, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_e, VR_b_pass_e, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_e, SR_sb_pass_e, SR_sb_fail_fj, SR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_e, VR_sb_pass_e, VR_sb_fail_fj, VR_sb_pass_fj, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j = Event_selection(input,process,event_counts,variation=variation,trigList=args.triggerList,refTrigList=args.refTriggerList,eventsToRead=None)
+        SR_b_fail_e, SR_b_pass_e, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_e, VR_b_pass_e, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_e, SR_sb_pass_e, SR_sb_fail_fj, SR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_e, VR_sb_pass_e, VR_sb_fail_fj, VR_sb_pass_fj, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j = Event_selection(input,process,event_counts,variation=variation,refTrigList=args.refTriggerList,trigList=args.triggerList,eventsToRead=None)
 
         if not saveOnceDone and variation in ["nominal","fromFile"]:
-            # give priority to nominal if running both 'nominal' and 'fromFile'
-            if variation=="nominal":
-                saveOnceDone = True
-
             event_counts["SR_boosted"]["Fail"] = len(SR_b_fail_fj)
             event_counts["SR_boosted"]["Pass"] = len(SR_b_pass_fj)
             event_counts["VR_boosted"]["Fail"] = len(VR_b_fail_fj)
@@ -206,28 +306,32 @@ if __name__ == "__main__":
             event_counts["VR_semiboosted"]["Fail"] += len(VR_sb_eq2_fail_fj)
             event_counts["VR_semiboosted"]["Pass"] += len(VR_sb_eq2_pass_fj)
 
+        # fill all histograms
+        # if doing trigger efficiency studies
+        if args.refTriggerList != None:
+            fillAllHistos(outHists, variation, event_counts, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j, SR_b_fail_e, SR_b_pass_e, VR_b_fail_e, VR_b_pass_e, SR_sb_fail_e, SR_sb_pass_e, VR_sb_fail_e, VR_sb_pass_e, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, args.refTriggerList)
+            # with analysis trigger included
+            if args.triggerList != None:
+                fillAllHistos(outHists, variation, event_counts, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j, SR_b_fail_e, SR_b_pass_e, VR_b_fail_e, VR_b_pass_e, SR_sb_fail_e, SR_sb_pass_e, VR_sb_fail_e, VR_sb_pass_e, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, args.refTriggerList, args.triggerList)
+        # normal selection
+        else:
+            fillAllHistos(outHists, variation, event_counts, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j)
+
+        if not saveOnceMCDone and "JetHT" not in process and variation in ["nominal","fromFile"]:
+            saveOnceMCDone = True
+            outHists[f"numberOfGenEventsHisto"] = numberOfGenEventsHisto
+
+        if not saveOnceDone and variation in ["nominal","fromFile"]:
+            # give priority to nominal if running both 'nominal' and 'fromFile'
+            if variation=="nominal":
+                saveOnceDone = True
+
             cutFlowHistos = {}
             for r in regions:
                 cutFlowHistos[r] = ROOT.TH1D(f"cutFlowHisto_{r}", f"{r};Cut flow;Number of events", len(event_counts[r].keys()), 0., float(len(event_counts[r].keys())))
                 for i, key in enumerate(event_counts[r].keys()):
                     cutFlowHistos[r].SetBinContent(i+1, event_counts[r][key])
                     cutFlowHistos[r].GetXaxis().SetBinLabel(i+1, key)
-
-        if (not saveOnceMCDone and "JetHT" not in process and variation in ["nominal","fromFile"]):
-            saveOnceMCDone = True
-            outHists[f"numberOfGenEventsHisto"] = numberOfGenEventsHisto
-
-        hists = {}
-        hists["boosted"] = fillHistos("Boosted", SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_fj, VR_b_pass_fj)           
-        hists["semiboosted"] = fillHistos("Semiboosted", SR_sb_fail_fj, SR_sb_pass_fj, VR_sb_fail_fj, VR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_j, VR_sb_pass_j)
-        hists["semiboosted_eq2"] = fillHistos("Semiboosted_eq2", SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j)
-
-        selections = ["boosted", "semiboosted", "semiboosted_eq2"]
-        suffix = ("" if variation=="fromFile" else f"_{variation}")
-
-        for sel in selections:
-            for hist in hists[sel]:
-                outHists[f"{hist}_{sel}{suffix}"] = hists[sel][hist]
 
     # save histograms to a ROOT file
     with uproot.recreate(os.path.join(output, "Histograms_{0}-{1}".format(process, ofile))) as fout:

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -218,6 +218,9 @@ def jecTagFromFileName(fname):
 def Event_selection(fname,process,event_counts,variation="nominal",trigList=None,refTrigList=None,eventsToRead=None):
     events = NanoEventsFactory.from_root(fname,schemaclass=NanoAODSchema,metadata={"dataset":process},entry_stop=eventsToRead).events()
 
+    for r in event_counts.keys():
+        event_counts[r]["Skim"] = len(events)
+
     if refTrigList != None:
         refTriggerBits = np.array([events.HLT[t] for t in refTrigList if t in events.HLT.fields])
         refTriggerMask = np.logical_or.reduce(refTriggerBits, axis=0)
@@ -229,7 +232,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
         events = events[triggerMask]
 
     for r in event_counts.keys():
-        event_counts[r]["Skim"] = len(events)
+        event_counts[r]["Trigger"] = len(events)
 
     # if JEC re-application is turned off
     if variation == "fromFile":

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -64,7 +64,7 @@ def precut(fatjets):
     return (fatjets.pt>ptcut) & (np.absolute(fatjets.eta)<etacut)
 
 
-def FailPassCategories(fatjets, jets=None):
+def FailPassCategories(events, fatjets, jets=None):
     # sort the fat jets in the descending pNet HbbvsQCD score
     sorted_fatjets = fatjets[ak.argsort(-HbbvsQCD(fatjets),axis=-1)]
 
@@ -73,9 +73,9 @@ def FailPassCategories(fatjets, jets=None):
     fail_mask = (HbbvsQCD(sorted_fatjets[:,0])<=pNet_cut)
     pass_mask = (HbbvsQCD(sorted_fatjets[:,0])>pNet_cut)
     if jets is not None:
-        return fatjets[fail_mask], fatjets[pass_mask], jets[fail_mask], jets[pass_mask]
+        return events[fail_mask], events[pass_mask], fatjets[fail_mask], fatjets[pass_mask], jets[fail_mask], jets[pass_mask]
     else:
-        return fatjets[fail_mask], fatjets[pass_mask]
+        return events[fail_mask], events[pass_mask], fatjets[fail_mask], fatjets[pass_mask]
 
 # this is a jet mask
 def HiggsMassCut(fatjets):
@@ -357,4 +357,4 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     # get good dijets
     fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2, events_VR_sb_eq2 = get_dijets(fatjets_VR_sb_eq2, jets_VR_sb_eq2, events_VR_sb_eq2, event_counts["VR_semiboosted"], True)
 
-    return *FailPassCategories(fatjets_SR_b), *FailPassCategories(fatjets_VR_b), *FailPassCategories(fatjets_SR_sb, good_dijets_SR_sb), *FailPassCategories(fatjets_VR_sb, good_dijets_VR_sb), *FailPassCategories(fatjets_SR_sb_eq2, good_dijets_SR_sb_eq2), *FailPassCategories(fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2)
+    return *FailPassCategories(events_SR_b, fatjets_SR_b), *FailPassCategories(events_VR_b, fatjets_VR_b), *FailPassCategories(events_SR_sb, fatjets_SR_sb, good_dijets_SR_sb), *FailPassCategories(events_VR_sb, fatjets_VR_sb, good_dijets_VR_sb), *FailPassCategories(events_SR_sb_eq2, fatjets_SR_sb_eq2, good_dijets_SR_sb_eq2), *FailPassCategories(events_VR_sb_eq2, fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2)

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -93,12 +93,13 @@ def VR_b_JetMass_evtMask(fatjets):
           & (fatjets[:,2].msoftdrop>=mass_cut[0]) & (fatjets[:,2].msoftdrop<=mass_cut[1]))
 
 
-def get_dijets(fatjets, jets, event_counts, addCounts=False):
+def get_dijets(fatjets, jets, events, event_counts, addCounts=False):
     # apply preselection to the resolved jets
     jets = jets[(jets.pt > res_ptcut) & (np.absolute(jets.eta) < res_etacut) & (jets.btagDeepB>res_deepBcut)]
 
     # require that there are at least 2 good jets present in the event
     fatjets = fatjets[ak.num(jets, axis=1)>1]
+    events  =  events[ak.num(jets, axis=1)>1]
     jets    =    jets[ak.num(jets, axis=1)>1]
 
     if addCounts:
@@ -112,6 +113,7 @@ def get_dijets(fatjets, jets, event_counts, addCounts=False):
 
     # require that there are at least 2 good away jets present in the event
     fatjets = fatjets[ak.num(jets, axis=1)>1]
+    events  =  events[ak.num(jets, axis=1)>1]
     jets    =    jets[ak.num(jets, axis=1)>1]
 
     if addCounts:
@@ -129,6 +131,7 @@ def get_dijets(fatjets, jets, event_counts, addCounts=False):
     
     # select events with at least 1 good dijet (by construction there can be at most 1 per event)
     fatjets     =     fatjets[ak.num(good_dijets, axis=1)>0]
+    events      =      events[ak.num(good_dijets, axis=1)>0]
     good_dijets = good_dijets[ak.num(good_dijets, axis=1)>0]
     
     if addCounts:
@@ -136,7 +139,7 @@ def get_dijets(fatjets, jets, event_counts, addCounts=False):
     else:
         event_counts["Good_dijet"] = len(fatjets)
     
-    return fatjets, good_dijets
+    return fatjets, good_dijets, events
 
 
 def getCalibratedAK4(events,variation,jetFactory,jecTag):
@@ -214,17 +217,17 @@ def jecTagFromFileName(fname):
 
 def Event_selection(fname,process,event_counts,variation="nominal",trigList=None,refTrigList=None,eventsToRead=None):
     events = NanoEventsFactory.from_root(fname,schemaclass=NanoAODSchema,metadata={"dataset":process},entry_stop=eventsToRead).events()
-        
-    if refTrigList != None:                
-        refTriggerBits = np.array([events.HLT[t] for t in refTrigList if t in events.HLT.fields])    
+
+    if refTrigList != None:
+        refTriggerBits = np.array([events.HLT[t] for t in refTrigList if t in events.HLT.fields])
         refTriggerMask = np.logical_or.reduce(refTriggerBits, axis=0)
         events = events[refTriggerMask]
 
     if trigList != None:
-        triggerBits = np.array([events.HLT[t] for t in trigList if t in events.HLT.fields])    
+        triggerBits = np.array([events.HLT[t] for t in trigList if t in events.HLT.fields])
         triggerMask = np.logical_or.reduce(triggerBits, axis=0)
         events = events[triggerMask]
-            
+
     for r in event_counts.keys():
         event_counts[r]["Skim"] = len(events)
 
@@ -267,13 +270,15 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     # select events with at least 3 good fat jets. Pass on only the 3 leading fat jets (to avoid events passing or failing due to the 4th or higher leading fat jet)
     fatjets_SR_b_evtMask = (ak.num(fatjets_SR, axis=1)>2)
     fatjets_SR_b = fatjets_SR[fatjets_SR_b_evtMask][:,0:3]
-
+    events_SR_b  = events_preselection[fatjets_SR_b_evtMask]
+    
     # VR boosted
     # apply the VR jet mass cuts to the 3 leading (in pT) fat jets and reject overlap with the SR.
     # Pass on only the 3 leading fat jets (to avoid events passing or failing due to the pNet score of the 4th or higher leading fat jet)
     fatjets_VR_b_evtMask = VR_b_JetMass_evtMask(fatjets)
     fatjets_VR_b = fatjets[fatjets_VR_b_evtMask & ~fatjets_SR_b_evtMask][:,0:3]
-
+    events_VR_b  = events_preselection[fatjets_VR_b_evtMask & ~fatjets_SR_b_evtMask]
+    
     event_counts["SR_boosted"]["Mass_cut"] = len(fatjets_SR_b)
     event_counts["VR_boosted"]["Mass_cut"] = len(fatjets_VR_b)
 
@@ -292,7 +297,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     event_counts["SR_semiboosted"]["Mass_cut_fatjets"] = len(fatjets_SR_sb)
 
     # get good dijets
-    fatjets_SR_sb, good_dijets_SR_sb = get_dijets(fatjets_SR_sb, jets_SR_sb, event_counts["SR_semiboosted"])
+    fatjets_SR_sb, good_dijets_SR_sb, events_SR_sb = get_dijets(fatjets_SR_sb, jets_SR_sb, events_SR_sb, event_counts["SR_semiboosted"])
 
     # VR semiboosted
     # select events with exactly 2 good fat jets and reject overlap with both SR and the VR boosted
@@ -311,7 +316,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     event_counts["VR_semiboosted"]["Mass_cut_fatjets"] = len(fatjets_VR_sb)
     
     # get good dijets
-    fatjets_VR_sb, good_dijets_VR_sb = get_dijets(fatjets_VR_sb, jets_VR_sb, event_counts["VR_semiboosted"])
+    fatjets_VR_sb, good_dijets_VR_sb, events_VR_sb = get_dijets(fatjets_VR_sb, jets_VR_sb, events_VR_sb, event_counts["VR_semiboosted"])
     
     # SR semiboosted (==2 fatjets)
     # apply the jet mass cut to preselected fat jets
@@ -329,7 +334,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     event_counts["SR_semiboosted"]["Mass_cut_fatjets"] += len(fatjets_SR_sb_eq2)
 
     # get good dijets
-    fatjets_SR_sb_eq2, good_dijets_SR_sb_eq2 = get_dijets(fatjets_SR_sb_eq2, jets_SR_sb_eq2, event_counts["SR_semiboosted"], True)
+    fatjets_SR_sb_eq2, good_dijets_SR_sb_eq2, events_SR_sb_eq2 = get_dijets(fatjets_SR_sb_eq2, jets_SR_sb_eq2, events_SR_sb_eq2, event_counts["SR_semiboosted"], True)
 
     # VR semiboosted (==2 fatjets)
     # apply the jet mass cut to preselected fat jets
@@ -347,6 +352,6 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     event_counts["VR_semiboosted"]["Mass_cut_fatjets"] += len(fatjets_VR_sb_eq2)
 
     # get good dijets
-    fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2 = get_dijets(fatjets_VR_sb_eq2, jets_VR_sb_eq2, event_counts["VR_semiboosted"], True)
+    fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2, events_VR_sb_eq2 = get_dijets(fatjets_VR_sb_eq2, jets_VR_sb_eq2, events_VR_sb_eq2, event_counts["VR_semiboosted"], True)
 
     return *FailPassCategories(fatjets_SR_b), *FailPassCategories(fatjets_VR_b), *FailPassCategories(fatjets_SR_sb, good_dijets_SR_sb), *FailPassCategories(fatjets_VR_sb, good_dijets_VR_sb), *FailPassCategories(fatjets_SR_sb_eq2, good_dijets_SR_sb_eq2), *FailPassCategories(fatjets_VR_sb_eq2, good_dijets_VR_sb_eq2)

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -218,8 +218,9 @@ def jecTagFromFileName(fname):
 def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=None,trigList=None,eventsToRead=None):
     events = NanoEventsFactory.from_root(fname,schemaclass=NanoAODSchema,metadata={"dataset":process},entry_stop=eventsToRead).events()
 
-    for r in event_counts.keys():
-        event_counts[r]["Skim"] = len(events)
+    if "JetHT" not in process:
+        for r in event_counts.keys():
+            event_counts[r]["Skim"] = len(events)
 
     if trigList != None and refTrigList == None:
         triggerBits = np.array([events.HLT[t] for t in trigList if t in events.HLT.fields])

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -215,28 +215,23 @@ def jecTagFromFileName(fname):
         jecTag = year+"Run"+era
         return jecTag
 
-def Event_selection(fname,process,event_counts,variation="nominal",trigList=None,refTrigList=None,eventsToRead=None):
+def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=None,trigList=None,eventsToRead=None):
     events = NanoEventsFactory.from_root(fname,schemaclass=NanoAODSchema,metadata={"dataset":process},entry_stop=eventsToRead).events()
 
     for r in event_counts.keys():
         event_counts[r]["Skim"] = len(events)
 
-    if refTrigList != None:
-        refTriggerBits = np.array([events.HLT[t] for t in refTrigList if t in events.HLT.fields])
-        refTriggerMask = np.logical_or.reduce(refTriggerBits, axis=0)
-        events = events[refTriggerMask]
-
-    if trigList != None:
+    if trigList != None and refTrigList == None:
         triggerBits = np.array([events.HLT[t] for t in trigList if t in events.HLT.fields])
         triggerMask = np.logical_or.reduce(triggerBits, axis=0)
         events = events[triggerMask]
 
-    for r in event_counts.keys():
-        event_counts[r]["Trigger"] = len(events)
+        for r in event_counts.keys():
+            event_counts[r]["Trigger"] = len(events)
 
     # if JEC re-application is turned off
     if variation == "fromFile":
-        print("JEC re-aplication turned off")
+        print("JEC re-application turned off")
         fatjets = events.FatJet
     else:
         with gzip.open(H3_DIR+"/../data/jec/jme_UL_pickled.pkl") as fin:

--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -249,12 +249,12 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     fatjets = fatjets[precut(fatjets)]
 
     # select events with exactly 2 preselected fat jets
-    events_preselection_eq2 =  events[ak.num(fatjets, axis=1)==2]
-    fatjets_eq2             = fatjets[ak.num(fatjets, axis=1)==2]
+    events_eq2  =  events[ak.num(fatjets, axis=1)==2]
+    fatjets_eq2 = fatjets[ak.num(fatjets, axis=1)==2]
 
     # select events with at least 3 preselected fat jets
-    events_preselection =  events[ak.num(fatjets, axis=1)>2]
-    fatjets             = fatjets[ak.num(fatjets, axis=1)>2]
+    events  =  events[ak.num(fatjets, axis=1)>2]
+    fatjets = fatjets[ak.num(fatjets, axis=1)>2]
 
     for r in event_counts.keys():
         if 'semiboosted' in r:
@@ -269,24 +269,24 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     # SR boosted
     # select events with at least 3 good fat jets. Pass on only the 3 leading fat jets (to avoid events passing or failing due to the 4th or higher leading fat jet)
     fatjets_SR_b_evtMask = (ak.num(fatjets_SR, axis=1)>2)
+    events_SR_b  =     events[fatjets_SR_b_evtMask]
     fatjets_SR_b = fatjets_SR[fatjets_SR_b_evtMask][:,0:3]
-    events_SR_b  = events_preselection[fatjets_SR_b_evtMask]
-    
+
     # VR boosted
     # apply the VR jet mass cuts to the 3 leading (in pT) fat jets and reject overlap with the SR.
     # Pass on only the 3 leading fat jets (to avoid events passing or failing due to the pNet score of the 4th or higher leading fat jet)
     fatjets_VR_b_evtMask = VR_b_JetMass_evtMask(fatjets)
+    events_VR_b  =  events[fatjets_VR_b_evtMask & ~fatjets_SR_b_evtMask]
     fatjets_VR_b = fatjets[fatjets_VR_b_evtMask & ~fatjets_SR_b_evtMask][:,0:3]
-    events_VR_b  = events_preselection[fatjets_VR_b_evtMask & ~fatjets_SR_b_evtMask]
-    
+
     event_counts["SR_boosted"]["Mass_cut"] = len(fatjets_SR_b)
     event_counts["VR_boosted"]["Mass_cut"] = len(fatjets_VR_b)
 
     # SR semiboosted
     # select events with exactly 2 good fat jets and reject overlap with the VR boosted (by construction orthogonal to the SR boosted)
     fatjets_SR_sb_evtMask = (ak.num(fatjets_SR, axis=1)==2)
-    events_SR_sb  = events_preselection[fatjets_SR_sb_evtMask & ~(fatjets_VR_b_evtMask)]
-    fatjets_SR_sb =          fatjets_SR[fatjets_SR_sb_evtMask & ~(fatjets_VR_b_evtMask)]
+    events_SR_sb  =     events[fatjets_SR_sb_evtMask & ~(fatjets_VR_b_evtMask)]
+    fatjets_SR_sb = fatjets_SR[fatjets_SR_sb_evtMask & ~(fatjets_VR_b_evtMask)]
     # get resolved jets from selected events
     # if JEC re-application is turned off
     if variation == "fromFile":
@@ -304,8 +304,8 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     fatjets_VR_sb = fatjets[:,0:2]
     fatjets_VR_sb = fatjets_VR_sb[HiggsMassVeto(fatjets_VR_sb)]
     fatjets_VR_sb_evtMask = (ak.num(fatjets_VR_sb, axis=1)==2)
-    events_VR_sb  = events_preselection[fatjets_VR_sb_evtMask & ~(fatjets_SR_b_evtMask | fatjets_SR_sb_evtMask | fatjets_VR_b_evtMask)]
-    fatjets_VR_sb =       fatjets_VR_sb[fatjets_VR_sb_evtMask & ~(fatjets_SR_b_evtMask | fatjets_SR_sb_evtMask | fatjets_VR_b_evtMask)]
+    events_VR_sb  =        events[fatjets_VR_sb_evtMask & ~(fatjets_SR_b_evtMask | fatjets_SR_sb_evtMask | fatjets_VR_b_evtMask)]
+    fatjets_VR_sb = fatjets_VR_sb[fatjets_VR_sb_evtMask & ~(fatjets_SR_b_evtMask | fatjets_SR_sb_evtMask | fatjets_VR_b_evtMask)]
     # get resolved jets from selected events
     # if JEC re-application is turned off
     if variation == "fromFile":
@@ -322,8 +322,8 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     # apply the jet mass cut to preselected fat jets
     fatjets_SR_sb_eq2 = fatjets_eq2[HiggsMassCut(fatjets_eq2)]
     # select events with exactly 2 good fat jets
-    events_SR_sb_eq2  = events_preselection_eq2[ak.num(fatjets_SR_sb_eq2, axis=1)==2]
-    fatjets_SR_sb_eq2 =       fatjets_SR_sb_eq2[ak.num(fatjets_SR_sb_eq2, axis=1)==2]
+    events_SR_sb_eq2  =        events_eq2[ak.num(fatjets_SR_sb_eq2, axis=1)==2]
+    fatjets_SR_sb_eq2 = fatjets_SR_sb_eq2[ak.num(fatjets_SR_sb_eq2, axis=1)==2]
     # get resolved jets from selected events
     # if JEC re-application is turned off
     if variation == "fromFile":
@@ -340,8 +340,8 @@ def Event_selection(fname,process,event_counts,variation="nominal",trigList=None
     # apply the jet mass cut to preselected fat jets
     fatjets_VR_sb_eq2 = fatjets_eq2[HiggsMassVeto(fatjets_eq2)]
     # select events with exactly 2 good fat jets
-    events_VR_sb_eq2  = events_preselection_eq2[ak.num(fatjets_VR_sb_eq2, axis=1)==2]
-    fatjets_VR_sb_eq2 =       fatjets_VR_sb_eq2[ak.num(fatjets_VR_sb_eq2, axis=1)==2]
+    events_VR_sb_eq2  =        events_eq2[ak.num(fatjets_VR_sb_eq2, axis=1)==2]
+    fatjets_VR_sb_eq2 = fatjets_VR_sb_eq2[ak.num(fatjets_VR_sb_eq2, axis=1)==2]
     # get resolved jets from selected events
     # if JEC re-application is turned off
     if variation == "fromFile":


### PR DESCRIPTION
This PR modifies the way trigger selection is applied for trigger efficiency studies. Before this PR reference and reference & analysis triggers were applied in separate jobs which led to problems with plotting efficiencies due to bin migrations, an effect which is still not fully understood. With this PR, whenever a reference triggers are being used, the trigger selection is applied at the end of the selection and one gets both the numerator (pass) and the denominator (total) histograms in the same job. If only analysis triggers are applied, the old behavior was kept where the trigger selection is applied as the start of the selection.