### PR TITLE
Ensuring that the jet calibrator runs on non-empty event arrays

### DIFF
--- a/Analysis/Selection.py
+++ b/Analysis/Selection.py
@@ -242,7 +242,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=N
 
         jecTag              = jecTagFromFileName(fname)
         print("JEC tag: ", jecTag)
-        fatjets             = getCalibratedAK8(events,variation,fatjetFactory,jecTag)
+        fatjets             = getCalibratedAK8(events,variation,fatjetFactory,jecTag) if len(events)>0 else events.FatJet
 
     # fat jet preselection
     fatjets = fatjets[precut(fatjets)]
@@ -291,7 +291,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=N
     if variation == "fromFile":
         jets_SR_sb = events_SR_sb.Jet
     else:
-        jets_SR_sb = getCalibratedAK4(events_SR_sb,variation,jetFactory,jecTag)
+        jets_SR_sb = getCalibratedAK4(events_SR_sb,variation,jetFactory,jecTag) if len(events_SR_sb)>0 else events_SR_sb.Jet
 
     event_counts["SR_semiboosted"]["Mass_cut_fatjets"] = len(fatjets_SR_sb)
 
@@ -310,7 +310,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=N
     if variation == "fromFile":
         jets_VR_sb = events_VR_sb.Jet
     else:
-        jets_VR_sb = getCalibratedAK4(events_VR_sb,variation,jetFactory,jecTag)
+        jets_VR_sb = getCalibratedAK4(events_VR_sb,variation,jetFactory,jecTag) if len(events_VR_sb)>0 else events_VR_sb.Jet
 
     event_counts["VR_semiboosted"]["Mass_cut_fatjets"] = len(fatjets_VR_sb)
     
@@ -328,7 +328,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=N
     if variation == "fromFile":
         jets_SR_sb_eq2 = events_SR_sb_eq2.Jet    
     else:
-        jets_SR_sb_eq2 = getCalibratedAK4(events_SR_sb_eq2,variation,jetFactory,jecTag)
+        jets_SR_sb_eq2 = getCalibratedAK4(events_SR_sb_eq2,variation,jetFactory,jecTag) if len(events_SR_sb_eq2)>0 else events_SR_sb_eq2.Jet
 
     event_counts["SR_semiboosted"]["Mass_cut_fatjets"] += len(fatjets_SR_sb_eq2)
 
@@ -346,7 +346,7 @@ def Event_selection(fname,process,event_counts,variation="nominal",refTrigList=N
     if variation == "fromFile":
         jets_VR_sb_eq2 = events_VR_sb_eq2.Jet
     else:
-        jets_VR_sb_eq2 = getCalibratedAK4(events_VR_sb_eq2,variation,jetFactory,jecTag)
+        jets_VR_sb_eq2 = getCalibratedAK4(events_VR_sb_eq2,variation,jetFactory,jecTag) if len(events_VR_sb_eq2)>0 else events_VR_sb_eq2.Jet
 
     event_counts["VR_semiboosted"]["Mass_cut_fatjets"] += len(fatjets_VR_sb_eq2)
 


### PR DESCRIPTION
When encountering empty event arrays, the jet calibrator was crashing the code with the following error message
```
Traceback (most recent call last):
  File "/users/ferencek/HHH/H3PO/Analysis/Mjj_Mjjj.py", line 407, in <module>
    SR_b_fail_e, SR_b_pass_e, SR_b_fail_fj, SR_b_pass_fj, VR_b_fail_e, VR_b_pass_e, VR_b_fail_fj, VR_b_pass_fj, SR_sb_fail_e, SR_sb_pass_e, SR_sb_fail_fj, SR_sb_pass_fj, SR_sb_fail_j, SR_sb_pass_j, VR_sb_fail_e, VR_sb_pass_e, VR_sb_fail_fj, VR_sb_pass_fj, VR_sb_fail_j, VR_sb_pass_j, SR_sb_eq2_fail_e, SR_sb_eq2_pass_e, SR_sb_eq2_fail_fj, SR_sb_eq2_pass_fj, SR_sb_eq2_fail_j, SR_sb_eq2_pass_j, VR_sb_eq2_fail_e, VR_sb_eq2_pass_e, VR_sb_eq2_fail_fj, VR_sb_eq2_pass_fj, VR_sb_eq2_fail_j, VR_sb_eq2_pass_j = Event_selection(input,process,event_counts,variation=variation,refTrigList=args.refTriggerList,trigList=args.triggerList,eventsToRead=None)
  File "/users/ferencek/HHH/H3PO/Analysis/Selection.py", line 294, in Event_selection
    jets_SR_sb = getCalibratedAK4(events_SR_sb,variation,jetFactory,jecTag)
  File "/users/ferencek/HHH/H3PO/Analysis/Selection.py", line 151, in getCalibratedAK4
    jetsCalib           = jetFactory[jecTag].build(addJECVariables(events.Jet, events.fixedGridRhoFastjetAll,isData), AK4jecCache)
  File "/users/ferencek/HHH/H3env/lib/python3.9/site-packages/coffea/jetmet_tools/CorrectedJetsFactory.py", line 246, in build
    seeds = numpy.array(out_dict[self.name_map["JetPt"] + "_orig"])[
IndexError: index 0 is out of bounds for axis 0 with size 0
```
This resulted in the output file missing which was messing up the calculation of the sample normalization. Even if for a particular file no events pass the selection, they still need to be taken into account for the computation of the total number of generated events.