### PR TITLE
Avoid division by zero in Xbb-tag systematics

### DIFF
--- a/Analysis/utils/xbbtag.py
+++ b/Analysis/utils/xbbtag.py
@@ -98,22 +98,28 @@ def get_ak8_xbbtag_weights_boosted(pass_mask, fail_mask, sf, eff):
     eff1 = eff[:,0]
     eff2 = eff[:,1]
     eff3 = eff[:,2]
-    
+
     # SFs for the leading 3 fat jets
     SF1 = sf[:,0]
     SF2 = sf[:,1]
     SF3 = sf[:,2]
-    
+
     # MC probability for the fail category
     prob_fail_MC = (1 - eff1) * (1 - eff2) * (1 - eff3)
     # DATA probability for the fail category (per-jet probabilitites restricted between 0. and 1.)
     prob_fail_DATA = ak_clip((1 - SF1*eff1), 0., 1.) * ak_clip((1 - SF2*eff2), 0., 1.) * ak_clip((1 - SF3*eff3), 0., 1.)
 
+    fail_den = ak.where(prob_fail_MC > 0, prob_fail_MC, 1.)
+    w_fail_ratio = prob_fail_DATA / fail_den
+
     # weights for the fail category
-    w_fail = ak.where(fail_mask, prob_fail_DATA / prob_fail_MC, 1.)
+    w_fail = ak.where(fail_mask & (prob_fail_MC > 0), w_fail_ratio, 1.)
+
+    pass_den = ak.where(prob_fail_MC < 1, 1 - prob_fail_MC, 1.)
+    w_pass_ratio = (1 - prob_fail_DATA) / pass_den
 
     # weights for the pass category
-    w_pass = ak.where(pass_mask, (1 - prob_fail_DATA) / (1 - prob_fail_MC), 1.)
+    w_pass = ak.where(pass_mask & (prob_fail_MC < 1), w_pass_ratio, 1.)
 
     return w_pass * w_fail
 
@@ -136,11 +142,17 @@ def get_ak8_xbbtag_weights_semiboosted(pass_mask, fail_mask, sf, eff):
     # DATA probability for the fail category (per-jet probabilitites restricted between 0. and 1.)
     prob_fail_DATA = ak_clip((1 - SF1*eff1), 0., 1.) * ak_clip((1 - SF2*eff2), 0., 1.)
 
+    fail_den = ak.where(prob_fail_MC > 0, prob_fail_MC, 1.)
+    w_fail_ratio = prob_fail_DATA / fail_den
+
     # weights for the fail category
-    w_fail = ak.where(fail_mask, prob_fail_DATA / prob_fail_MC, 1.)
+    w_fail = ak.where(fail_mask & (prob_fail_MC > 0), w_fail_ratio, 1.)
+
+    pass_den = ak.where(prob_fail_MC < 1, 1 - prob_fail_MC, 1.)
+    w_pass_ratio = (1 - prob_fail_DATA) / pass_den
 
     # weights for the pass category
-    w_pass = ak.where(pass_mask, (1 - prob_fail_DATA) / (1 - prob_fail_MC), 1.)
+    w_pass = ak.where(pass_mask & (prob_fail_MC < 1), w_pass_ratio, 1.)
 
     return w_pass * w_fail
 


### PR DESCRIPTION
After merging https://github.com/CMS-H3PO/H3PO/pull/59, started getting the following warning messages
```
/users/ferencek/HHH/H3env/lib/python3.9/site-packages/awkward/_connect/_numpy.py:197: RuntimeWarning: invalid value encountered in true_divide
  result = getattr(ufunc, method)(
/users/ferencek/HHH/H3env/lib/python3.9/site-packages/awkward/_connect/_numpy.py:197: RuntimeWarning: divide by zero encountered in true_divide
  result = getattr(ufunc, method)(
```
This PR protects against such cases.

Note that replacing
```Python
 w_fail = ak.where(fail_mask, prob_fail_DATA / prob_fail_MC, 1.)
 ```
 with
 ```Python
 w_fail = ak.where(fail_mask & (prob_fail_MC > 0), prob_fail_DATA / prob_fail_MC, 1.)
 ```
is not sufficient because the division is evaluated first and `ak.where` then selects the result. This unfortunately makes the code a bit more clunky.